### PR TITLE
Refactor GraphQL API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ An example output is:
   // ...
 ]
 ```
+
+## Showcase
+**[6chinwei/codepen-repository](https://github.com/6chinwei/codepen-repository)**  
+Automatically download all public pens from [codepen.io/6chinwei](https://codepen.io/6chinwei) and commit the source code to Git repository.  

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2",
     "vitest": "^2.1.8"
+  },
+  "dependencies": {
+    "gql-query-builder": "^3.8.0"
   }
 }

--- a/src/codePenApiRequestHeaders.ts
+++ b/src/codePenApiRequestHeaders.ts
@@ -1,0 +1,73 @@
+/**
+ * Custom Headers for CodePen API requests.
+ */
+export default class CodePenApiRequestHeaders extends Headers {
+  private static readonly DEFAULT_INDEX_URL = 'https://codepen.io/';
+
+  private indexUrl: string = CodePenApiRequestHeaders.DEFAULT_INDEX_URL;
+
+  constructor() {
+    super();
+
+    // Set default headers
+    this.set('Accept', '*/*');
+    this.set('Content-Type', 'application/json');
+    this.set('X-Requested-With', 'XMLHttpRequest');
+  }
+
+  /**
+   * Setup CSRF headers for subsequent API requests.
+   *
+   * This method sends a request to the CodePen INDEX_URL
+   * to retrieve the CSRF token and cookie.
+   */
+  public async setupCsrfHeaders (): Promise<void> {
+    const response = await this.sendRequestToIndex();
+    const csrfToken = await this.findCsrfToken(response);
+    const csrfCookie = this.findCsrfCookie(response);
+
+    this.set('X-Csrf-Token', csrfToken);
+    this.set('Cookie', csrfCookie);
+
+    return;
+  }
+
+  public setIndexUrl (indexUrl: string): CodePenApiRequestHeaders {
+    this.indexUrl = indexUrl;
+
+    return this;
+  }
+
+  protected async sendRequestToIndex (): Promise<Response> {
+    // Headers to open index page
+    const headers = {
+      'Accept': 'text/html',
+      'Upgrade-Insecure-Requests': '1',
+    };
+
+    return await fetch(this.indexUrl, { headers });
+  }
+
+  protected async findCsrfToken (response: Response): Promise<string> {
+    const html = await response.text();
+    const [, token] = (/<meta name="csrf-token"\s+content="([^"]+)"/.exec(html)) ?? [];
+
+    if (!token) {
+      throw new Error('CSRF token not found');
+    }
+
+    return token;
+  }
+
+  protected findCsrfCookie (response: Response): string {
+    const cookieName = 'cp_session';
+    const cookieHeader = response.headers.get('set-cookie')?.split(',') ?? [];
+    const cookie = cookieHeader.find(cookie => cookie.startsWith(`${cookieName}=`))?.split(';')[0];
+
+    if (!cookie) {
+      throw new Error('CSRF cookie not found');
+    }
+
+    return cookie;
+  }
+}

--- a/src/codePenGraphqlApi.ts
+++ b/src/codePenGraphqlApi.ts
@@ -1,116 +1,39 @@
 import { Pen, FetchPensOptions, UserProfile, GetPenResponse, GetProfileResponse, GetPensResponse } from './types';
+import { default as ApiRequestHeaders } from './codePenApiRequestHeaders';
+import { default as QueryBuilder } from './codePenGraphqlQueryBuilder';
 
 export default class CodePenGraphqlApi {
-  private static readonly DEFAULT_API_URL = 'https://codepen.io/graphql';
-  private static readonly DEFAULT_INDEX_URL = 'https://codepen.io/';
+  protected static readonly DEFAULT_API_URL = 'https://codepen.io/graphql';
 
-  private apiUrl: string;
-  private indexUrl: string;
-  private headers: HeadersInit;
-  private penFields: string;
+  protected apiRequestHeaders: ApiRequestHeaders;
+  protected apiQueryBuilder: QueryBuilder;
+  protected apiUrl: string;
 
-  constructor(config: { apiUrl?: string, indexUrl?: string } = {}) {
+  constructor (config: { apiUrl?: string } = {}) {
+    this.apiRequestHeaders = new ApiRequestHeaders();
+    this.apiQueryBuilder = new QueryBuilder();
     this.apiUrl = config.apiUrl ?? CodePenGraphqlApi.DEFAULT_API_URL;
-    this.indexUrl = config.indexUrl ?? CodePenGraphqlApi.DEFAULT_INDEX_URL;
-    this.headers = {
-      'Accept': '*/*',
-      'Content-Type': 'application/json',
-      'X-Requested-With': 'XMLHttpRequest',
-    };
-    this.penFields = `
-      access
-      config {
-        css
-        cssPreProcessor
-        head
-        html
-        js
-        jsPreProcessor
-      }
-      createdAt
-      description {
-        source {
-          body
-        }
-      }
-      id
-      owner {
-        id
-        username
-      }
-      tags
-      title
-      updatedAt
-      url`;
   }
 
   public async init(): Promise<CodePenGraphqlApi> {
-    await this.setupCsrfHeaders();
+    await this.apiRequestHeaders.setupCsrfHeaders();
 
     return this;
   }
 
   /**
-   * Setup CSRF headers for subsequent requests.
-   *
-   * This method sends a request to the CodePen index URL
-   * to retrieve the CSRF token and cookie.
-   */
-  protected async setupCsrfHeaders(): Promise<void> {
-    const headers = {
-      'Accept': 'text/html',
-      'Upgrade-Insecure-Requests': '1',
-    };
-
-    const response = await fetch(this.indexUrl, { headers });
-    const csrfToken = await this.findCsrfToken(response);
-    const csrfCookie = this.findCsrfCookie(response);
-
-    this.headers = {
-      ...this.headers,
-      'X-Csrf-Token': csrfToken,
-      'Cookie': csrfCookie,
-    };
-  }
-
-  protected async findCsrfToken(response: Response): Promise<string> {
-    const html = await response.text();
-    const [, token] = (/<meta name="csrf-token"\s+content="([^"]+)"/.exec(html)) ?? [];
-
-    if (!token) {
-      throw new Error('CSRF token not found');
-    }
-
-    return token;
-  }
-
-  protected findCsrfCookie(response: Response): string {
-    const cookieName = 'cp_session';
-    const cookieHeader = response.headers.get('set-cookie')?.split(',') ?? [];
-    const cookie = cookieHeader.find(cookie => cookie.startsWith(`${cookieName}=`))?.split(';')[0];
-
-    if (!cookie) {
-      throw new Error('CSRF cookie not found');
-    }
-
-    return cookie;
-  }
-
-
-  /**
-   * Executes a GraphQL query with the provided query string and variables.
+   * Executes a GraphQL query with the provided query.
    *
    * @template T - The expected return type of the GraphQL query.
-   * @param {string} query - The GraphQL query string.
-   * @param {Record<string, unknown>} variables - The variables to be used in the GraphQL query.
-   * @returns A promise that resolves to the result of the GraphQL query.
+   * @param query - The GraphQL query.
+   * @returns A promise that resolves to the result.
    * @throws Throws an error if the fetch operation fails.
    */
-  protected async executeGraphqlQuery<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  protected async executeGraphqlQuery<T> (query: string): Promise<T> {
     const options: RequestInit = {
       method: 'POST',
-      headers: this.headers,
-      body: JSON.stringify({ query, variables }),
+      headers: this.apiRequestHeaders,
+      body: query,
       redirect: 'follow'
     };
 
@@ -126,59 +49,23 @@ export default class CodePenGraphqlApi {
     }
   }
 
-  public async getPenById(penId: string): Promise<Pen> {
-    const variables = { penId };
-    const query = `query getPenById ($penId: ID!) {
-          pen(id: $penId) {${this.penFields}}
-        }`;
-    const result = await this.executeGraphqlQuery<GetPenResponse>(query, variables);
+  public async getPenById (penId: string): Promise<Pen> {
+    const query = this.apiQueryBuilder.buildGetPenByIdQuery(penId);
+    const result = await this.executeGraphqlQuery<GetPenResponse>(query);
 
     return result.data.pen;
   }
 
-  public async getPensByUserId(userId: string, options: FetchPensOptions = {}): Promise<Pen[]> {
-    const variables = {
-      input: {
-        filters: {
-          userId
-        },
-        pagination: {
-          cursor: options?.cursor ?? undefined,
-          limit: options?.limit ?? 10,
-          sortBy: options?.sortBy ?? undefined,
-          sortOrder: options?.sortOrder ?? undefined
-        }
-      }
-    };
-    const query = `query getPensByUserId ($input: PensInput!) {
-        pens(input: $input) {
-          pens {${this.penFields}}
-        }
-      }`;
-    const result = await this.executeGraphqlQuery<GetPensResponse>(query, variables);
+  public async getPensByUserId (userId: string, options: FetchPensOptions = {}): Promise<Pen[]> {
+    const query = this.apiQueryBuilder.buildGetPensByUserIdQuery(userId, options);
+    const result = await this.executeGraphqlQuery<GetPensResponse>(query);
 
     return result.data.pens.pens;
   }
 
-  public async getProfileByUsername(username: string): Promise<UserProfile> {
-    const variables = { username };
-    const query = `query getProfileByUsername ($username: String!) {
-        ownerByUsername(ownerUsername: $username, ownerType: User) {
-          avatar
-          bio
-          counts {
-            followers
-            following
-            pens
-          }
-          id
-          location
-          name
-          pro
-          username
-        }
-      }`;
-    const result = await this.executeGraphqlQuery<GetProfileResponse>(query, variables);
+  public async getProfileByUsername (username: string): Promise<UserProfile> {
+    const query = this.apiQueryBuilder.buildGetProfileByUsernameQuery(username);
+    const result = await this.executeGraphqlQuery<GetProfileResponse>(query);
 
     return result.data.ownerByUsername;
   }

--- a/src/codePenGraphqlQueryBuilder.ts
+++ b/src/codePenGraphqlQueryBuilder.ts
@@ -1,0 +1,106 @@
+import { query as buildQuery } from 'gql-query-builder';
+import { FetchPensOptions } from './types';
+
+export default class CodePenGraphqlQueryBuilder {
+  /**
+   * @return The pen fields you want to retrieve from the GraphQL API
+   */
+  protected getPenFields (): Array<string | object> {
+    return [
+      'access',
+      {
+        'config': [
+          'css',
+          'cssPreProcessor',
+          'head',
+          'html',
+          'js',
+          'jsPreProcessor'
+        ]
+      },
+      'createdAt',
+      { 'description': [{ 'source' : ['body'] }] },
+      'id',
+      { 'owner': ['id', 'username'] },
+      'tags',
+      'title',
+      'updatedAt',
+      'url',
+    ];
+  }
+
+  /**
+   * @return The user profile fields you want to retrieve from the GraphQL API
+   */
+  protected getUserProfileFields (): Array<string | object> {
+    return [
+      'avatar',
+      'bio',
+      {
+        'counts': ['followers', 'following', 'pens']
+      },
+      'id',
+      'location',
+      'name',
+      'pro',
+      'username',
+    ];
+  }
+
+  public buildGetPenByIdQuery (penId: string): string {
+    const query = buildQuery({
+      operation: 'pen',
+      variables: {
+        id: { value: penId, type: 'ID', required: true }
+      },
+      fields: this.getPenFields()
+    }, null, { operationName: 'getPenById' });
+
+    return JSON.stringify(query);
+  }
+
+  public buildGetPensByUserIdQuery (userId: string, options: FetchPensOptions = {}): string {
+    const query = buildQuery({
+      operation: 'pens',
+      variables: {
+        input: this.buildPensInput(userId, options)
+      },
+      fields: [{
+        pens: this.getPenFields()
+      }]
+    }, null, { operationName: 'getPensByUserId' });
+
+    return JSON.stringify(query);
+  }
+
+  protected buildPensInput (userId: string, options : FetchPensOptions = {}): Record<string, string | boolean | object> {
+    return {
+      value: {
+        filters: {
+          userId
+        },
+        pagination: {
+          cursor: options.cursor,
+          limit: options?.limit ?? 10,
+          sortBy: options.sortBy,
+          sortOrder: options.sortOrder
+        }
+      },
+      type: 'PensInput',
+      required: true
+    };
+  }
+
+  public buildGetProfileByUsernameQuery (username: string): string {
+    const query = buildQuery({
+      operation: 'ownerByUsername',
+      variables: {
+        ownerUsername: { value: username, type: 'String', required: true },
+        ownerType: { value: 'User', type: 'OwnerEnum', required: true }
+      },
+      fields: this.getUserProfileFields()
+    }, null, { operationName: 'getProfileByUsername' });
+
+    return JSON.stringify(query);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 import CodePenGraphqlApi from './codePenGraphqlApi';
 import { Pen, FetchPensOptions, UserProfile } from './types';
 
-let api: CodePenGraphqlApi | null = null;
-
-async function initializeApi() {
-  if (!api) {
-    api = new CodePenGraphqlApi();
-    await api.init();
-  }
-}
+const api = new CodePenGraphqlApi();
 
 /**
  * Fetch a pen by its ID, which can be found in the URL of the pen.
@@ -16,9 +9,8 @@ async function initializeApi() {
  * @param penId
  */
 export async function fetchPen(penId: string): Promise<Pen> {
-  await initializeApi();
-
-  return await api!.getPenById(penId);
+  return (await api.init())
+    .getPenById(penId);
 };
 
 /**
@@ -27,9 +19,8 @@ export async function fetchPen(penId: string): Promise<Pen> {
  * @param username
  */
 export async function fetchProfile(username: string): Promise<UserProfile> {
-  await initializeApi();
-
-  return await api!.getProfileByUsername(username);
+  return (await api.init())
+    .getProfileByUsername(username);
 }
 
 /**
@@ -39,9 +30,8 @@ export async function fetchProfile(username: string): Promise<UserProfile> {
  * @param options
  */
 export async function fetchPensByUserId(userId: string, options: FetchPensOptions = {}): Promise<Pen[]> {
-  await initializeApi();
-
-  return await api!.getPensByUserId(userId, options);
+  return (await api.init())
+    .getPensByUserId(userId, options);
 };
 
 export { Pen, FetchPensOptions, UserProfile } from './types';

--- a/tests/fetchPen.test.ts
+++ b/tests/fetchPen.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockApiResponse } from './utils';
-import { fetchPen } from '../src/index';
-import { Pen, GetPenResponse } from '../src/types';
+import { fetchPen, Pen } from '../src/index';
+import { GetPenResponse } from '../src/types';
 
 describe('fetchPen', () => {
   beforeEach(() => {

--- a/tests/fetchPensByUserId.test.ts
+++ b/tests/fetchPensByUserId.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockApiResponse } from './utils';
-import { fetchPensByUserId } from '../src/index';
-import { Pen, GetPensResponse, FetchPensOptions } from '../src/types';
+import { fetchPensByUserId, Pen, FetchPensOptions } from '../src/index';
+import { GetPensResponse } from '../src/types';
 
 describe('fetchPensByUserId', () => {
   beforeEach(() => {

--- a/tests/fetchProfile.test.ts
+++ b/tests/fetchProfile.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mockApiResponse } from './utils';
-import { fetchProfile } from '../src/index';
-import { UserProfile, GetProfileResponse } from '../src/types';
+import { fetchProfile, UserProfile } from '../src/index';
+import { GetProfileResponse } from '../src/types';
 
 describe('fetchProfile', () => {
   beforeEach(() => {


### PR DESCRIPTION
- Introduce [atulmy/gql-query-builder](https://github.com/atulmy/gql-query-builder) to build query for more maintainability.
- Refactor for ApiHeader / GraphqlApi / QueryBuilder.
- Add a link to [6chinwei/codepen-repository](https://github.com/6chinwei/codepen-repository) as a showcase in README.

