### PR TITLE
Add a workflow for integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,26 @@
+name: Integration Test
+
+on:
+  schedule:
+    - cron: '0 1 * * 1' # Every Monday at 9 AM (UTC+8)
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - run: npm install
+      - run: npm run build
+      - name: Install dependencies for integration test
+        run: npm install
+        working-directory: tests/integration
+      - run: npm run test:integration

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Unit Test
 
 on:
   push:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           node-version: '20.x'
       - run: npm install
-      - run: npm run build # Build to lint the code for integration tests
       - run: npm run lint
       - run: |
           npm run test:unit -- \

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
-    "lint": "eslint .",
+    "lint": "eslint . --ignore-pattern tests/integration",
     "test": "vitest --dir tests/unit",
     "test:unit": "vitest run --dir tests/unit --coverage --coverage.reporter text",
     "test:integration": "vitest run --dir tests/integration"

--- a/tests/integration/fetchPen.test.ts
+++ b/tests/integration/fetchPen.test.ts
@@ -3,7 +3,7 @@ import { fetchPen, Pen } from '../../dist/index';
 
 describe('fetchPen', () => {
 
-  it('should fetch pen by ID: JoPRMeB', async () => {
+  it('should fetch pen by ID: JoPRMeB', { retry: 2 }, async () => {
     const penId = 'JoPRMeB'; // ID of an example pen
 
     const pen: Pen = await fetchPen(penId);

--- a/tests/integration/fetchPen.test.ts
+++ b/tests/integration/fetchPen.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fetchPen, Pen } from '../../dist/index';
+import { fetchPen, Pen } from 'codepen-fetcher';
 
 describe('fetchPen', () => {
 

--- a/tests/integration/fetchPensByUserId.test.ts
+++ b/tests/integration/fetchPensByUserId.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fetchPensByUserId, Pen } from '../../dist/index';
+import { fetchPensByUserId, Pen } from 'codepen-fetcher';
 
 describe('fetchPensByUserId', () => {
 

--- a/tests/integration/fetchPensByUserId.test.ts
+++ b/tests/integration/fetchPensByUserId.test.ts
@@ -3,7 +3,7 @@ import { fetchPensByUserId, Pen } from '../../dist/index';
 
 describe('fetchPensByUserId', () => {
 
-  it('should return pens of 6chinwei', async () => {
+  it('should return pens of 6chinwei', { retry: 2 }, async () => {
     const userId = 'DEnXWE'; // ID of @6chinwei
     const options = { limit: 5 };
 

--- a/tests/integration/fetchProfile.test.ts
+++ b/tests/integration/fetchProfile.test.ts
@@ -3,7 +3,7 @@ import { fetchProfile, UserProfile } from '../../dist/index';
 
 describe('fetchProfile', () => {
 
-  it('should return profile of 6chinwei', async () => {
+  it('should return profile of 6chinwei', { retry: 2 }, async () => {
     const username = '6chinwei';
 
     const profile: UserProfile = await fetchProfile(username);

--- a/tests/integration/fetchProfile.test.ts
+++ b/tests/integration/fetchProfile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fetchProfile, UserProfile } from '../../dist/index';
+import { fetchProfile, UserProfile } from 'codepen-fetcher';
 
 describe('fetchProfile', () => {
 

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "codepen-fetcher-integration-tests",
+  "type": "module",
+  "dependencies": {
+    "codepen-fetcher": "file:../../"
+  }
+}


### PR DESCRIPTION
- Add a workflow for integration tests, which test the local package built from `npm run build`
- Exclude the code of integration tests from linting in CI
- Adjust unit test workflow:
  - Rename it from `Test` to `Unit Test`
  - Remove the unused `npm install` step before running the unit tests