### PR TITLE
Update `README.md` for badges and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CodePen Fetcher
   
-[![Node Current](https://img.shields.io/node/v/codepen-fetcher)](https://www.npmjs.com/package/codepen-fetcher) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/6chinwei/codepen-fetcher/test.yaml?branch=main&label=Test)](https://github.com/6chinwei/codepen-fetcher/actions/workflows/test.yaml) ![Codecov](https://img.shields.io/codecov/c/gh/6chinwei/codepen-fetcher)
+[![Node Current](https://img.shields.io/node/v/codepen-fetcher)](https://www.npmjs.com/package/codepen-fetcher) 
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/6chinwei/codepen-fetcher/unit-test.yaml?branch=main&label=unit+test)](https://github.com/6chinwei/codepen-fetcher/actions/workflows/unit-test.yaml) 
+[![Codecov](https://img.shields.io/codecov/c/gh/6chinwei/codepen-fetcher)](https://app.codecov.io/gh/6chinwei/codepen-fetcher/)
 
 An unofficial CodePen Node.js library built with TypeScript, capable of fetching the HTML, CSS, and JS source code of public Pens without authentication. It is designed for use in workflow automation tasks.
 

--- a/README.md
+++ b/README.md
@@ -136,5 +136,9 @@ $ npm run test:unit
 # Build the project first
 $ npm run build
 
+# Install local dependencies for integration tests
+$ npm install --prefix tests/integration
+
+# Run integration tests
 $ npm run test:integration
 ```


### PR DESCRIPTION
- Fix the badge of unit tests, which is broken in #9
- Add a link for the badge of coverage
- Update the document for running integration tests