### PR TITLE
Add API initializer and error handling

### DIFF
--- a/src/codePenApiInitializer.ts
+++ b/src/codePenApiInitializer.ts
@@ -1,0 +1,28 @@
+import { type CodePenApi } from './types';
+import CodePenGraphqlApi from './codePenGraphqlApi';
+import ApiRequestHeaders from './codePenApiRequestHeaders';
+import QueryBuilder from './codePenGraphqlQueryBuilder';
+
+let codePenApi: CodePenApi | undefined;
+let initPromise: Promise<CodePenApi> | undefined;
+
+export async function makeCodePenApiInstance(): Promise<CodePenApi> {
+  if (codePenApi) {
+    return codePenApi;
+  }
+
+  if (!initPromise) {
+    initPromise = initializeCodePenGraphqlApi();
+  }
+
+  return initPromise;
+}
+
+async function initializeCodePenGraphqlApi(): Promise<CodePenApi> {
+  const apiRequestHeaders = new ApiRequestHeaders();
+  const queryBuilder = new QueryBuilder();
+
+  codePenApi = await new CodePenGraphqlApi(apiRequestHeaders, queryBuilder).init();
+
+  return codePenApi;
+}

--- a/src/codePenGraphqlApi.ts
+++ b/src/codePenGraphqlApi.ts
@@ -1,8 +1,8 @@
-import type  { Pen, FetchPensOptions, UserProfile, GetPenResponse, GetProfileResponse, GetPensResponse, GraphqlPayload } from './types';
+import type { CodePenApi, Pen, FetchPensOptions, UserProfile, GetPenResponse, GetProfileResponse, GetPensResponse, GraphqlPayload } from './types';
 import ApiRequestHeaders from './codePenApiRequestHeaders';
 import QueryBuilder from './codePenGraphqlQueryBuilder';
 
-export default class CodePenGraphqlApi {
+export default class CodePenGraphqlApi implements CodePenApi {
   protected static readonly API_URL = 'https://codepen.io/graphql';
 
   protected apiRequestHeaders: ApiRequestHeaders;

--- a/src/codePenGraphqlApi.ts
+++ b/src/codePenGraphqlApi.ts
@@ -40,13 +40,24 @@ export default class CodePenGraphqlApi implements CodePenApi {
 
     try {
       const response = await fetch(CodePenGraphqlApi.API_URL, options);
+
+      if (!response.ok) {
+        throw new Error(
+          `response status: ${response.status} ${response.statusText}`
+        );
+      }
+
       const data = await response.json() as T;
 
       return data;
     } catch (error) {
       console.error('Fetch error:', error);
 
-      throw new Error('Failed to fetch data');
+      throw new Error(
+        `Failed to execute GraphQL query: ${payload.query}. Error: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,5 @@
 import type { Pen, FetchPensOptions, UserProfile } from './types';
-import CodePenGraphqlApi from './codePenGraphqlApi';
-import ApiRequestHeaders from './codePenApiRequestHeaders';
-import QueryBuilder from './codePenGraphqlQueryBuilder';
-
-let codePenApi: CodePenGraphqlApi | undefined;
-let initPromise: Promise<CodePenGraphqlApi> | undefined;
-
-async function makeCodePenApiInstance() {
-  if (codePenApi) {
-    return codePenApi;
-  }
-
-  if (!initPromise) {
-    // Prevent duplicate initialization by using the same Promise
-    initPromise = (async () => {
-      const apiRequestHeaders = new ApiRequestHeaders();
-      const queryBuilder = new QueryBuilder();
-
-      codePenApi = await (new CodePenGraphqlApi(apiRequestHeaders, queryBuilder)).init();
-
-      return codePenApi;
-    })();
-  }
-
-  return initPromise;
-}
+import { makeCodePenApiInstance } from './codePenApiInitializer';
 
 /**
  * Fetch a pen by its ID, which can be found in the URL of the pen.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export interface CodePenApi {
+  getPenById(penId: string): Promise<Pen>;
+  getProfileByUsername(username: string): Promise<UserProfile>;
+  getPensByUserId(userId: string, options?: FetchPensOptions): Promise<Pen[]>;
+}
+
 export type Pen = {
   access: string;
   config: {

--- a/tests/unit/codePenApiInitializer.test.ts
+++ b/tests/unit/codePenApiInitializer.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
+import type { CodePenApi } from '../../src/types';
+
+const mockApi: CodePenApi = {
+  getPenById: vi.fn(),
+  getProfileByUsername: vi.fn(),
+  getPensByUserId: vi.fn(),
+};
+
+const mockInit = vi.fn().mockResolvedValue(mockApi);
+
+vi.mock('../../src/codePenGraphqlApi', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    init: mockInit
+  })),
+}));
+vi.mock('../../src/codePenApiRequestHeaders', () => ({
+  default: vi.fn(),
+}));
+vi.mock('../../src/codePenGraphqlQueryBuilder', () => ({
+  default: vi.fn(),
+}));
+
+describe('codePenApiInitializer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should initialize CodePenGraphqlApi only once and return the same instance', async () => {
+    const { makeCodePenApiInstance } = await import('../../src/codePenApiInitializer');
+    const instance1 = await makeCodePenApiInstance();
+    const instance2 = await makeCodePenApiInstance();
+
+    expect(instance1).toBe(instance2);
+    expectTypeOf(instance1).toEqualTypeOf<CodePenApi>();
+    expect(mockInit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return the same promise when called concurrently', async () => {
+    const { makeCodePenApiInstance } = await import('../../src/codePenApiInitializer');
+    const promise1 = makeCodePenApiInstance();
+    const promise2 = makeCodePenApiInstance();
+
+    expect(promise1).toStrictEqual(promise2);
+    expectTypeOf(promise1).toEqualTypeOf<Promise<CodePenApi>>();
+
+    const [instance1, instance2] = await Promise.all([promise1, promise2]);
+
+    expect(instance1).toBe(instance2);
+    expect(mockInit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/codePenGraphqlApi.test.ts
+++ b/tests/unit/codePenGraphqlApi.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import CodePenGraphqlApi from '../../src/codePenGraphqlApi';
 import ApiRequestHeaders from '../../src/codePenApiRequestHeaders';
 import QueryBuilder from '../../src/codePenGraphqlQueryBuilder';
-import { mockFetchJson } from './utils';
+import { mockFetchJson, mockFetchError } from './utils';
 
 describe('CodePenGraphqlApi', () => {
   let api: CodePenGraphqlApi;
@@ -95,5 +95,13 @@ describe('CodePenGraphqlApi', () => {
 
     expect(mockQueryBuilder.buildGetPensByUserIdQuery).toHaveBeenCalledWith(userId, options);
     expect(result).toEqual(pens);
+  });
+
+  it('should throw an error', async () => {
+    const mockStatusCode = 404;
+
+    mockFetchError(mockStatusCode, 'Not Found');
+
+    await expect(() => api.getPenById('abc123')).rejects.toThrowError(`${mockStatusCode}`);
   });
 });

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -66,18 +66,4 @@ describe('CodePen Fetcher', () => {
     expect(mockCodePenApi.getPensByUserId).toHaveBeenCalledWith(userId, undefined);
     expect(result).toEqual(pens);
   });
-
-  it('init() should only be called once', async () => {
-    const penId = '12345';
-    const pen = { id: penId, title: 'Test Pen' };
-
-    mockCodePenApi.getPenById.mockResolvedValue(pen);
-
-    const { fetchPen } = await import('../../src/');
-
-    await fetchPen(penId);
-    await fetchPen(penId);
-
-    expect(mockCodePenApi.getPenById).toHaveBeenCalledTimes(2);
-  });
 });

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,20 +1,20 @@
-import type { FetchPensOptions, Pen, UserProfile } from '../../src/types';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CodePenApi } from '../../src/types';
 
-const mockCodePenGraphqlApi = {
-  init: vi.fn(),
-  getPenById: vi.fn(),
-  getProfileByUsername: vi.fn(),
-  getPensByUserId: vi.fn()
+// Allow MockCodePenApi to inherit all structure of CodePenApi
+type MockCodePenApi = {
+  [K in keyof CodePenApi]: ReturnType<typeof vi.fn> & CodePenApi[K];
 };
 
-vi.mock('../../src/codePenGraphqlApi', () => {
-  return {
-    default: vi.fn().mockImplementation(() => mockCodePenGraphqlApi),
-  };
-});
-vi.mock('../../src/codePenApiRequestHeaders', () => ({ default: vi.fn()}));
-vi.mock('../../src/codePenGraphqlQueryBuilder', () => ({ default: vi.fn()}));
+const mockCodePenApi: MockCodePenApi = {
+  getPenById: vi.fn(),
+  getProfileByUsername: vi.fn(),
+  getPensByUserId: vi.fn(),
+};
+
+vi.mock('../../src/codePenApiInitializer', () => ({
+  makeCodePenApiInstance: vi.fn(() => Promise.resolve(mockCodePenApi)),
+}));
 
 describe('CodePen Fetcher', () => {
   beforeEach(() => {
@@ -24,67 +24,60 @@ describe('CodePen Fetcher', () => {
 
   it('fetchPen() should fetch a pen by its ID', async () => {
     const penId = '12345';
-    const pen = { id: penId, title: 'Test Pen' } as Pen;
+    const pen = { id: penId, title: 'Test Pen' };
 
-    mockCodePenGraphqlApi.init.mockResolvedValue(mockCodePenGraphqlApi);
-    mockCodePenGraphqlApi.getPenById.mockResolvedValue(pen);
+    mockCodePenApi.getPenById.mockResolvedValue(pen);
 
     const { fetchPen } = await import('../../src/');
+
     const result = await fetchPen(penId);
 
-    expect(mockCodePenGraphqlApi.init).toHaveBeenCalled();
-    expect(mockCodePenGraphqlApi.getPenById).toHaveBeenCalledWith(penId);
+    expect(mockCodePenApi.getPenById).toHaveBeenCalledWith(penId);
     expect(result).toEqual(pen);
   });
 
   it('fetchProfile() should fetch a user profile by username', async () => {
     const username = 'testuser';
-    const profile = { username, name: 'Test User' } as UserProfile;
+    const profile = { username, name: 'Test User' };
 
-    mockCodePenGraphqlApi.init.mockResolvedValue(mockCodePenGraphqlApi);
-    mockCodePenGraphqlApi.getProfileByUsername.mockResolvedValue(profile);
+    mockCodePenApi.getProfileByUsername.mockResolvedValue(profile);
 
     const { fetchProfile } = await import('../../src/');
+
     const result = await fetchProfile(username);
 
-    expect(mockCodePenGraphqlApi.init).toHaveBeenCalled();
-    expect(mockCodePenGraphqlApi.getProfileByUsername).toHaveBeenCalledWith(username);
+    expect(mockCodePenApi.getProfileByUsername).toHaveBeenCalledWith(username);
     expect(result).toEqual(profile);
   });
 
   it('fetchPensByUserId() should fetch pens by a user id', async () => {
     const userId = 'user123';
-    const options = { limit: 10, a: 1 } as FetchPensOptions;
     const pens = [
       { id: 'pen1', title: 'Pen 1' },
       { id: 'pen2', title: 'Pen 2' },
-    ] as Pen[];
+    ];
 
-    mockCodePenGraphqlApi.init.mockResolvedValue(mockCodePenGraphqlApi);
-    mockCodePenGraphqlApi.getPensByUserId.mockResolvedValue(pens);
+    mockCodePenApi.getPensByUserId.mockResolvedValue(pens);
 
     const { fetchPensByUserId } = await import('../../src/');
-    const result = await fetchPensByUserId(userId, options);
 
-    expect(mockCodePenGraphqlApi.init).toHaveBeenCalled();
-    expect(mockCodePenGraphqlApi.getPensByUserId).toHaveBeenCalledWith(userId, options);
+    const result = await fetchPensByUserId(userId);
+
+    expect(mockCodePenApi.getPensByUserId).toHaveBeenCalledWith(userId, undefined);
     expect(result).toEqual(pens);
   });
 
   it('init() should only be called once', async () => {
     const penId = '12345';
-    const pen = { id: penId, title: 'Test Pen' } as Pen;
+    const pen = { id: penId, title: 'Test Pen' };
 
-    mockCodePenGraphqlApi.init.mockResolvedValue(mockCodePenGraphqlApi);
-    mockCodePenGraphqlApi.getPenById.mockResolvedValue(pen);
+    mockCodePenApi.getPenById.mockResolvedValue(pen);
 
     const { fetchPen } = await import('../../src/');
 
     await fetchPen(penId);
     await fetchPen(penId);
-    await fetchPen(penId);
 
-    expect(mockCodePenGraphqlApi.init).toHaveBeenCalledTimes(1);
-    expect(mockCodePenGraphqlApi.getPenById).toHaveBeenCalledTimes(3);
+    expect(mockCodePenApi.getPenById).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -2,7 +2,19 @@ import { vi } from 'vitest';
 
 export function mockFetchJson (responseData: unknown) {
   const mockResponse = {
+    ok: true,
     json: vi.fn().mockResolvedValue(responseData)
+  };
+
+  return vi.spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce(mockResponse as unknown as Response);
+}
+
+export function mockFetchError (status: number, statusText?: string) {
+  const mockResponse = {
+    ok: false,
+    status: status,
+    statusText: statusText || '',
   };
 
   return vi.spyOn(globalThis, 'fetch')


### PR DESCRIPTION
- Add a `CodePenApi` interface
- Add a `CodePenApiInitializer`
- Update the error handler for GraphQL API
- Update unit tests