### PR TITLE
Update the supported Node.js version to `>=18` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ $ npm install --prefix tests/integration
 # Run integration tests
 $ npm run test:integration
 ```
+
+### Node.js compatibility tests
+See [6chinwei/codepen-fetcher-compatibility-test](https://github.com/6chinwei/codepen-fetcher-compatibility-test) for more details.
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:integration": "vitest run --dir tests/integration"
   },
   "engines": {
-    "node": ">20.0.0"
+    "node": ">=18"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Update the supported Node.js version to `>=18` based on the test results from [6chinwei/codepen-fetcher-compatibility-test](https://github.com/6chinwei/codepen-fetcher-compatibility-test)
- Add a section about Node.js compatibility tests in README