### PR TITLE
Use Node v24 for development

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js based on `package.json`
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version-file: 'package.json'
           cache: 'npm'
           cache-dependency-path: package.json
       - run: npm install

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version-file: 'package.json'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+      - name: Use Node.js based on `package.json`
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version-file: 'package.json'
       - run: npm install
       - run: npm run lint
       - run: |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Automatically download all public pens from [codepen.io/6chinwei](https://codepe
 
 ## Development
 1. Clone the repo
-2. Use Node.js v20 or later
+2. Use Node.js v24 or later. (Recommended to use [Volta](https://volta.sh/))
 3. Install dependencies
    ```bash
    $ npm install  

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "node": ">=18"
   },
+  "volta": {
+    "node": "24.3.0"
+  },
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
- Add a Volta config for using Node.js v24.3.0
- Set Node.js version based on `package.json` in all CI jobs