### PR TITLE
Handle potential `null` responses from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An unofficial CodePen Node.js library built with TypeScript, capable of fetching the HTML, CSS, and JS source code of public Pens without authentication. It is designed for use in workflow automation tasks.
 
-This library uses a workaround to retrieve data via the `https://codepen.io/graphql` API, which may break if the API changes.
+This library uses a workaround to retrieve data via the `https://codepen.io/graphql` API.
 
 ## Installation
 ```bash
@@ -17,7 +17,7 @@ $ npm install codepen-fetcher
 ### Fetch a pen
 Fetch a pen by its `penId`, which can be found in the URL of the pen. For example, the `penId` of https://codepen.io/6chinwei/pen/gbYRQmN is `gbYRQmN`.
 
-```javascript
+```ts
 import { fetchPen } from 'codepen-fetcher';
 
 const penId = 'gbYRQmN';
@@ -25,7 +25,7 @@ const pen = await fetchPen(penId);
 console.log(pen);
 ```
 Example output is:
-```javascript
+```ts
 {
   access: 'Public',
   config: {
@@ -51,7 +51,7 @@ Note that the source code of the pen is stored in the `config` object.
 ### Fetch a user profile
 Fetch a CodePen user's profile (e.g., ID and Name) by their username.
 
-```javascript
+```ts
 import { fetchProfile } from 'codepen-fetcher';
 
 const username = '6chinwei';
@@ -59,7 +59,7 @@ const userProfile = await fetchProfile(username);
 console.log(userProfile);
 ```
 An example output is:
-```javascript
+```ts
 {
   avatar: 'https://assets.codepen.io/1103539/internal/avatars/users/default.png?format=auto&version=1734538260',
   bio: '',
@@ -72,16 +72,18 @@ An example output is:
 ```
 
 ### Fetch pens by user ID
-```javascript
+Fetch pens owned by a specific user (using their user ID, not username).
+
+```ts
 import { fetchPensByUserId } from 'codepen-fetcher';
+
 const userId = 'DEnXWE';
 const options = { limit: 5 };
-
 const pens = await fetchPensByUserId(userId, options);
 console.log(pens);
 ```
 An example output is:
-```javascript
+```ts
 [
   {
     access: 'Public',

--- a/src/codePenGraphqlApi.ts
+++ b/src/codePenGraphqlApi.ts
@@ -61,16 +61,16 @@ export default class CodePenGraphqlApi implements CodePenApi {
     }
   }
 
-  public async getPenById (penId: string): Promise<Pen> {
+  public async getPenById (penId: string): Promise<Pen|null> {
     const payload = {
       query: this.apiQueryBuilder.buildGetPenByIdQuery(penId)
     };
     const result = await this.executeGraphqlQuery<GetPenResponse>(payload);
 
-    return result.data.pen;
+    return result.data?.pen || null;
   }
 
-  public async getProfileByUsername (username: string): Promise<UserProfile> {
+  public async getProfileByUsername (username: string): Promise<UserProfile|null> {
     const payload = {
       query: this.apiQueryBuilder.buildGetProfileByUsernameQuery(username)
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,30 +2,64 @@ import type { Pen, FetchPensOptions, UserProfile } from './types';
 import { makeCodePenApiInstance } from './codePenApiInitializer';
 
 /**
- * Fetch a pen by its ID, which can be found in the URL of the pen.
+ * Fetch a pen by its ID
  *
- * @param penId
+ * @param penId The ID of the pen. It can be found in the URL of the pen. For example, the `penId` of https://codepen.io/6chinwei/pen/gbYRQmN is `gbYRQmN`.
+ * @return A Promise that resolves to a `Pen` object or `null` if the pen does not exist.
+ * @example Fetch a pen by ID
+ * ```ts
+ * import { fetchPen } from 'codepen-fetcher';
+ * const pen = await fetchPen('gbYRQmN'); // a `Pen` object
+ * ```
+ * @example Fetch a not-existing pen
+ * ```ts
+ * import { fetchPen } from 'codepen-fetcher';
+ * const pen = await fetchPen('notExistPenId'); // null
+ * ```
  */
-export async function fetchPen(penId: string): Promise<Pen> {
+export async function fetchPen(penId: string): Promise<Pen|null> {
   return (await makeCodePenApiInstance())
     .getPenById(penId);
 }
 
 /**
- * Fetch a user profile by username.
+ * Fetch a CodePen user's profile (e.g., ID and Name) by their username.
  *
- * @param username
+ * @param username The username of a CodePen user.
+ * @return A Promise that resolves to a `UserProfile` object or `null` if the user does not exist.
+ * @example Fetch a user profile by username
+ * ```ts
+ * import { fetchProfile } from 'codepen-fetcher';
+ * const profile = await fetchProfile('6chinwei'); // a `UserProfile` object
+ * ```
+ * @example Fetch a not-existing user profile
+ * ```ts
+ * import { fetchProfile } from 'codepen-fetcher';
+ * const profile = await fetchProfile('notExistUsername'); // null
+ * ```
  */
-export async function fetchProfile(username: string): Promise<UserProfile> {
+export async function fetchProfile(username: string): Promise<UserProfile|null> {
   return (await makeCodePenApiInstance())
     .getProfileByUsername(username);
 }
 
 /**
- * Fetch pens created by a specific user.
+ * Fetch pens owned by a specific user (using their user ID, not username).
  *
- * @param userId
- * @param options
+ * @param userId The ID of the user.
+ * @param options Optional settings for fetching.
+ * @param options.cursor A cursor string for pagination. Defaults is `undefined`.
+ * @param options.limit Maximum number of pens to return. Defaults is `10`.
+ * @param options.sortBy Field to sort by: `'Id'`, `'Popularity'`, or `'UpdatedAt'`. Defaults is `undefined`.
+ * @param options.sortOrder Sort direction: `'Asc'` or `'Desc'`. Defaults is `undefined`.
+ * @returns A Promise that resolves to an array of `Pen` objects.
+ * @example Fetch pens by user ID
+ * ```ts
+ * import { fetchPensByUserId } from 'codepen-fetcher';
+ * const userId = 'DEnXWE'; // ID of the user: `6chinwei`
+ * const options = { limit: 5 };
+ * const pens = await fetchPensByUserId(userId, options); // an array of `Pen` objects
+ * ```
  */
 export async function fetchPensByUserId(userId: string, options?: FetchPensOptions): Promise<Pen[]> {
   return (await makeCodePenApiInstance())

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface CodePenApi {
-  getPenById(penId: string): Promise<Pen>;
-  getProfileByUsername(username: string): Promise<UserProfile>;
+  getPenById(penId: string): Promise<Pen|null>;
+  getProfileByUsername(username: string): Promise<UserProfile|null>;
   getPensByUserId(userId: string, options?: FetchPensOptions): Promise<Pen[]>;
 }
 
@@ -56,12 +56,12 @@ export type UserProfile = {
 export type GetPenResponse = {
   data: {
     pen: Pen;
-  };
+  } | null;
 };
 
 export type GetProfileResponse = {
   data: {
-    ownerByUsername: UserProfile;
+    ownerByUsername: UserProfile|null;
   };
 };
 

--- a/tests/integration/fetchPen.test.ts
+++ b/tests/integration/fetchPen.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { fetchPen, Pen } from 'codepen-fetcher';
+import { fetchPen } from 'codepen-fetcher';
 
 describe('fetchPen', () => {
 
   it('should fetch pen by ID: JoPRMeB', { retry: 2 }, async () => {
     const penId = 'JoPRMeB'; // ID of an example pen
 
-    const pen: Pen = await fetchPen(penId);
+    const pen = await fetchPen(penId);
 
-    expect(pen.id).toEqual(penId);
+    expect(pen?.id).toEqual(penId);
   });
 });

--- a/tests/integration/fetchPensByUserId.test.ts
+++ b/tests/integration/fetchPensByUserId.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fetchPensByUserId, Pen } from 'codepen-fetcher';
+import { fetchPensByUserId, type Pen } from 'codepen-fetcher';
 
 describe('fetchPensByUserId', () => {
 

--- a/tests/integration/fetchProfile.test.ts
+++ b/tests/integration/fetchProfile.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { fetchProfile, UserProfile } from 'codepen-fetcher';
+import { fetchProfile } from 'codepen-fetcher';
 
 describe('fetchProfile', () => {
 
   it('should return profile of 6chinwei', { retry: 2 }, async () => {
     const username = '6chinwei';
 
-    const profile: UserProfile = await fetchProfile(username);
+    const profile = await fetchProfile(username);
 
-    expect(profile.username).toEqual(username);
+    expect(profile?.username).toEqual(username);
   });
 });

--- a/tests/unit/codePenGraphqlApi.test.ts
+++ b/tests/unit/codePenGraphqlApi.test.ts
@@ -57,6 +57,17 @@ describe('CodePenGraphqlApi', () => {
     expect(result).toEqual(pen);
   });
 
+  it('should return null if the pen does not exist', async () => {
+    const mockPenResponse: GetPenResponse = { data: null };
+
+    mockFetchJson(mockPenResponse);
+
+    const result = await api.getPenById('notExistPenId');
+
+    expect(result).toBeNull();
+
+  });
+
   it('should fetch a user profile by username', async () => {
     const profile: UserProfile = {
       id: '1',
@@ -74,6 +85,16 @@ describe('CodePenGraphqlApi', () => {
 
     expect(mockQueryBuilder.buildGetProfileByUsernameQuery).toHaveBeenCalledWith(profile.username);
     expect(result).toEqual(profile);
+  });
+
+  it('should return null if the user does not exist', async () => {
+    const mockProfileResponse: GetProfileResponse = { data: { ownerByUsername: null } };
+
+    mockFetchJson(mockProfileResponse);
+
+    const result = await api.getProfileByUsername('notExistUsername');
+
+    expect(result).toBeNull();
   });
 
   it('should fetch pens by user ID', async () => {
@@ -97,7 +118,7 @@ describe('CodePenGraphqlApi', () => {
     expect(result).toEqual(pens);
   });
 
-  it('should throw an error', async () => {
+  it('should throw an error if API responds error', async () => {
     const mockStatusCode = 404;
 
     mockFetchError(mockStatusCode, 'Not Found');


### PR DESCRIPTION
- Handle potential `null` responses from the CodePen API when fetching a pen or a user that does not exist.
- Update test cases and documents