### PR TITLE
Remove `NPM_TOKEN` from npm publish step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,5 +19,3 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This repo already uses [Trusted Publishing for npm packages](https://docs.npmjs.com/trusted-publishers) so `NODE_AUTH_TOKEN` is no longer required for publishing.