### PR TITLE
Fix types and test coverage for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsup src/index.ts --format esm --dts",
     "lint": "eslint . --ignore-pattern tests/integration",
     "test": "vitest --dir tests/unit",
-    "test:unit": "vitest run --dir tests/unit --coverage --coverage.reporter text",
+    "test:unit": "vitest run --dir tests/unit --coverage --coverage.reporter text --coverage.include=\"src/**/*.ts\"",
     "test:integration": "vitest run --dir tests/integration"
   },
   "engines": {

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { CodePenApi } from '../../src/types';
+import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
+import type { CodePenApi, Pen, UserProfile } from '../../src/types';
 
-// Allow MockCodePenApi to inherit all structure of CodePenApi
 type MockCodePenApi = {
-  [K in keyof CodePenApi]: ReturnType<typeof vi.fn> & CodePenApi[K];
+  [K in keyof CodePenApi]: MockedFunction<CodePenApi[K]>;
 };
 
 const mockCodePenApi: MockCodePenApi = {
@@ -24,7 +23,7 @@ describe('CodePen Fetcher', () => {
 
   it('fetchPen() should fetch a pen by its ID', async () => {
     const penId = '12345';
-    const pen = { id: penId, title: 'Test Pen' };
+    const pen = { id: penId, title: 'Test Pen' } as Pen;
 
     mockCodePenApi.getPenById.mockResolvedValue(pen);
 
@@ -38,7 +37,7 @@ describe('CodePen Fetcher', () => {
 
   it('fetchProfile() should fetch a user profile by username', async () => {
     const username = 'testuser';
-    const profile = { username, name: 'Test User' };
+    const profile = { username, name: 'Test User' } as UserProfile;
 
     mockCodePenApi.getProfileByUsername.mockResolvedValue(profile);
 
@@ -55,7 +54,7 @@ describe('CodePen Fetcher', () => {
     const pens = [
       { id: 'pen1', title: 'Pen 1' },
       { id: 'pen2', title: 'Pen 2' },
-    ];
+    ] as Pen[];
 
     mockCodePenApi.getPensByUserId.mockResolvedValue(pens);
 


### PR DESCRIPTION
After #22, Vitest 4 changed the types of `vi.fn()` and the coverage behavior, causing loaded test helper files (e.g. `tests/unit/utils.ts`) to be included in coverage results.

This PR: 
- uses `MockedFunction` instead of `ReturnType<typeof vi.fn>`
- explicitly sets `coverage.include` to limit unit test coverage collection to the `src` folder.

### Before
```
$ npm run test:unit
...

% Coverage report from v8
--------------------------------|---------|----------|---------|---------|-------------------
File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------|---------|----------|---------|---------|-------------------
All files                       |     100 |    91.42 |     100 |     100 |                   
 src                            |     100 |    93.75 |     100 |     100 |                   
  codePenApiInitializer.ts      |     100 |      100 |     100 |     100 |                   
  codePenApiRequestHeaders.ts   |     100 |     87.5 |     100 |     100 | 60                
  codePenGraphqlApi.ts          |     100 |    83.33 |     100 |     100 | 58                
  codePenGraphqlQueryBuilder.ts |     100 |      100 |     100 |     100 |                   
  index.ts                      |     100 |      100 |     100 |     100 |                   
 tests/unit                     |     100 |    66.66 |     100 |     100 |                   
  utils.ts                      |     100 |    66.66 |     100 |     100 | 17                
--------------------------------|---------|----------|---------|---------|-------------------
```

### After
```
% Coverage report from v8
-------------------------------|---------|----------|---------|---------|-------------------
File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------------|---------|----------|---------|---------|-------------------
All files                      |     100 |    93.75 |     100 |     100 |                   
 codePenApiInitializer.ts      |     100 |      100 |     100 |     100 |                   
 codePenApiRequestHeaders.ts   |     100 |     87.5 |     100 |     100 | 60                
 codePenGraphqlApi.ts          |     100 |    83.33 |     100 |     100 | 58                
 codePenGraphqlQueryBuilder.ts |     100 |      100 |     100 |     100 |                   
 index.ts                      |     100 |      100 |     100 |     100 |                   
 types.ts                      |       0 |        0 |       0 |       0 |                   
-------------------------------|---------|----------|---------|---------|-------------------
```